### PR TITLE
HV Connector Electric Connector recipe change

### DIFF
--- a/scripts/temporary scripts/Temp_ingot_recipe_fix.zs
+++ b/scripts/temporary scripts/Temp_ingot_recipe_fix.zs
@@ -169,7 +169,7 @@ recipes.remove(<immersiveengineering:connector:5>);
 
 // HV Wire Relay: Aluminum -> Nickel
 recipes.addShaped(<immersiveengineering:connector:5> * 8, 
-	[[null, <ore:ingotNickel>, null],
+	[[null, <magneticraft:connector>, null],
 	[<immersiveengineering:stone_decoration:8>, <ore:ingotNickel>, <immersiveengineering:stone_decoration:8>], 
 	[<immersiveengineering:stone_decoration:8>, <ore:ingotNickel>, <immersiveengineering:stone_decoration:8>]]);
 	
@@ -178,7 +178,7 @@ recipes.remove(<immersiveengineering:connector:4>);
 
 // HV Wire Connector: Aluminum -> Nickel
 recipes.addShaped(<immersiveengineering:connector:4> * 4, 
-	[[null, <ore:ingotNickel>, null],
+	[[null, <magneticraft:connector>, null],
 	[<minecraft:hardened_clay>, <ore:ingotNickel>, <minecraft:hardened_clay>], 
 	[<minecraft:hardened_clay>, <ore:ingotNickel>, <minecraft:hardened_clay>]]);
 


### PR DESCRIPTION
Replaces the top center slot in the HV Wire Relay and HV Wire connector to Magneticraft's Electric Connector. Changed due to number 44. in needed-recipes.