### PR TITLE
Orechid

### DIFF
--- a/scripts/temporary scripts/Temp_orechid.zs
+++ b/scripts/temporary scripts/Temp_orechid.zs
@@ -9,7 +9,16 @@ mods.botania.Orechid.removeOre(<ore:oreRuby>);
 mods.botania.Orechid.removeOre(<ore:orePeridot>);
 mods.botania.Orechid.removeOre(<ore:oreCobalt>);
 mods.botania.Orechid.removeOre(<ore:oreGalena>);
- 
+mods.botania.Orechid.removeOre(<ore:oreApatite>);
+mods.botania.Orechid.removeOre(<ore:orePlatinum>);
+mods.botania.Orechid.removeOre(<ore:oreUranium>);
+
+// Removes Cobaltite ore from Cobalt oredictionary
+<ore:oreCobalt>.remove(<magneticraft:ores:2>);
+
+// Increased Nickel chance in orechid
+mods.botania.Orechid.addOre(<ore:oreNickel>, 12000);
+
 // Makes the oredict entry "blockMossyCobblestone" for only Moss Stone
 val myEntry = <ore:blockMossyCobblestone>;
 myEntry.add(<minecraft:mossy_cobblestone>);


### PR DESCRIPTION
- Removed Apatite, Platinum, and Uranium ore from generating in Orechid
- Removed Cobaltite from Cobalt ore oredictionary
+ Increased the chance of Nickel ore generating in Orechid