### PR TITLE
fixes magneticraft sieve and sluice box recipes

### DIFF
--- a/scripts/temporary scripts/Temp_magneticraft.zs
+++ b/scripts/temporary scripts/Temp_magneticraft.zs
@@ -142,20 +142,26 @@ recipes.addShapedMirrored(<magneticraft:connector> * 2,
 #Script by DolphinBlaster
 //Removes lead, aluminum and silver dust as biproducts
 	
-// Iron Rocky Chunk Sluice Box recipe removal
+// Iron Rocky Chunk Sluice Box & Sieve recipe removal
 mods.magneticraft.SluiceBox.removeRecipe(<magneticraft:rocky_chunks>);
- 
-// Iron Rocky Chunk Sluice Box recipe without Aluminum Dust
-mods.magneticraft.SluiceBox.addRecipe(<minecraft:iron_ore>, 1.0, <magneticraft:chunks>, 0.15, <thermalfoundation:material:69>, 0.15, <minecraft:cobblestone>, true);
- 
+mods.magneticraft.Sieve.removeRecipe(<magneticraft:rocky_chunks:0>);
+
+// Iron Rocky Chunk Sluice Box & Sieve recipe without Aluminum Dust
+mods.magneticraft.SluiceBox.addRecipe(<magneticraft:rocky_chunks:0>, 1.0, <magneticraft:chunks>, 0.15, <thermalfoundation:material:69>, 0.15, <minecraft:cobblestone>, 0.05, <thermalfoundation:material:771>, true);
+mods.magneticraft.Sieve.addRecipe(<minecraft:rocky_chunks:0>, <magneticraft:chunks>, 1.0, <thermalfoundation:material:69>, 0.15, <thermalfoundation:material:771>, 0.10, 50, true);
+
 // Gold Rocky Chunk Sluice Box recipe removal
 mods.magneticraft.SluiceBox.removeRecipe(<magneticraft:rocky_chunks:1>);
- 
-// Gold Rocky Chunk Sluice Box recipe without Silver Dust
-mods.magneticraft.SluiceBox.addRecipe(<minecraft:gold_ore>, 1.0, <magneticraft:chunks:1>, 0.15, <thermalfoundation:material:64>, 0.15, <minecraft:cobblestone>, true);
- 
-// Cobalt Rocky Chunk Sluice Box recipe removal
+mods.magneticraft.Sieve.removeRecipe(<magneticraft:rocky_chunks:0>);
+
+// Gold Rocky Chunk Sluice Box & Sieve recipe without Silver Dust
+mods.magneticraft.SluiceBox.addRecipe(<magneticraft:rocky_chunks:1>, 1.0, <magneticraft:chunks:1>, 0.15, <thermalfoundation:material:64>, 0.15, <minecraft:cobblestone>, true);
+mods.magneticraft.Sieve.addRecipe(<minecraft:rocky_chunks:1>, <magneticraft:chunks:1>, 1.0, <thermalfoundation:material:64>, 0.15, <thermalfoundation:material:771>, 0, 50, true);
+
+// Cobalt Rocky Chunk Sluice & Sieve Box recipe removal
 mods.magneticraft.SluiceBox.removeRecipe(<magneticraft:rocky_chunks:4>);
- 
-// Cobalt Rocky Chunk Sluice Box recipe without Mithril Dust and Osmium Dust
-mods.magneticraft.SluiceBox.addRecipe(<minecraft:gold_ore>, 1.0, <magneticraft:chunks:4>, 0.15, <minecraft:netherrack>, true);
+mods.magneticraft.Sieve.removeRecipe(<magneticraft:rocky_chunks:0>);
+
+// Cobalt Rocky Chunk Sluice Box & Sieve recipe without Mithril Dust and Osmium Dust
+mods.magneticraft.SluiceBox.addRecipe(<magneticraft:rocky_chunks:4>, 1.0, <magneticraft:chunks:4>, 0.15, <minecraft:netherrack>, true);
+mods.magneticraft.Sieve.addRecipe(<minecraft:rocky_chunks:4>, <magneticraft:chunks:4>, 1.0, <thermalfoundation:material:64>, 0, <thermalfoundation:material:771>, 0, 50, true);


### PR DESCRIPTION
sluice box recipes now properly take rocky chunks
sieve recipes now don't give silver, aluminum, mithril, or osmium dust
iron rocky chunks have a slight chance of giving sulfur (b/c pyrite exists irl)