### PR TITLE
Redstone paradox patch 1

### DIFF
--- a/scripts/general scripts/forestry.zs
+++ b/scripts/general scripts/forestry.zs
@@ -17,4 +17,4 @@ recipes.removeShaped(<forestry:wood_pile>);
 recipes.addShaped(<forestry:wood_pile>,
 [[<ore:logWood>,<ore:string>,<ore:logWood>],
 [<ore:string>,<ore:string>,<ore:string>],
-[<ore:logWood>,<ore:string>,<ore:logWood>]];
+[<ore:logWood>,<ore:string>,<ore:logWood>]]);

--- a/scripts/general scripts/forestry.zs
+++ b/scripts/general scripts/forestry.zs
@@ -11,3 +11,10 @@ val itemsToDisable =[
   <forestry:peat_bog:*>,
 ] as IItemStack[];  //note: Disabled to encourage more complex farms
 scripts.functions.disableItems(itemsToDisable);
+
+//Foresty log piles
+recipes.removeShaped(<forestry:wood_pile>);
+recipes.addShapedd(<forestry:wood_pile>,
+[[<ore:logWood>,<ore:string>,<ore:logWood>],
+[<ore:string>,<ore:string>,<ore:string>],
+[<ore:logWood>,<ore:string>,<ore:logWood>]]

--- a/scripts/general scripts/forestry.zs
+++ b/scripts/general scripts/forestry.zs
@@ -1,7 +1,7 @@
 import crafttweaker.item.IItemStack;
 //disable forestry farms
 val itemsToDisable =[
-  <forestry:ffarm:*>,
+  <forestry:farm:*>,
   <forestry:arboretum:*>,
   <forestry:farm_crops:*>,
   <forestry:farm_mushroom:*>,

--- a/scripts/general scripts/forestry.zs
+++ b/scripts/general scripts/forestry.zs
@@ -14,7 +14,7 @@ scripts.functions.disableItems(itemsToDisable);
 
 //Foresty log piles
 recipes.removeShaped(<forestry:wood_pile>);
-recipes.addShapedd(<forestry:wood_pile>,
+recipes.addShaped(<forestry:wood_pile>,
 [[<ore:logWood>,<ore:string>,<ore:logWood>],
 [<ore:string>,<ore:string>,<ore:string>],
 [<ore:logWood>,<ore:string>,<ore:logWood>]];

--- a/scripts/general scripts/forestry.zs
+++ b/scripts/general scripts/forestry.zs
@@ -1,7 +1,7 @@
 import crafttweaker.item.IItemStack;
 //disable forestry farms
 val itemsToDisable =[
-  <forestry:farm:*>,
+  <forestry:ffarm:*>,
   <forestry:arboretum:*>,
   <forestry:farm_crops:*>,
   <forestry:farm_mushroom:*>,

--- a/scripts/general scripts/forestry.zs
+++ b/scripts/general scripts/forestry.zs
@@ -17,4 +17,4 @@ recipes.removeShaped(<forestry:wood_pile>);
 recipes.addShapedd(<forestry:wood_pile>,
 [[<ore:logWood>,<ore:string>,<ore:logWood>],
 [<ore:string>,<ore:string>,<ore:string>],
-[<ore:logWood>,<ore:string>,<ore:logWood>]]
+[<ore:logWood>,<ore:string>,<ore:logWood>]];

--- a/scripts/general scripts/quark.zs
+++ b/scripts/general scripts/quark.zs
@@ -1,0 +1,3 @@
+//Remove bark recipe
+
+recipes.removeShaped(<quark:bark>);

--- a/scripts/general scripts/quark.zs
+++ b/scripts/general scripts/quark.zs
@@ -1,3 +1,10 @@
 //Remove bark recipe
 
-recipes.removeShaped(<quark:bark>);
+//Remove bark recipe
+
+recipes.removeShaped(<quark:bark:0>);
+recipes.removeShaped(<quark:bark:1>);
+recipes.removeShaped(<quark:bark:2>);
+recipes.removeShaped(<quark:bark:3>);
+recipes.removeShaped(<quark:bark:4>);
+recipes.removeShaped(<quark:bark:5>);


### PR DESCRIPTION
Changed the recipe for Forestry wood piles to use logs and string and removed quark's bark recipe as requested by Deviant.