### PR TITLE
Match Nickel spawn rate with Orechid to Gold

### DIFF
--- a/scripts/mod-specific scripts/botania.zs
+++ b/scripts/mod-specific scripts/botania.zs
@@ -72,7 +72,7 @@ mods.botania.Orechid.removeOre(<ore:oreUranium>);
 <ore:oreCobalt>.remove(<magneticraft:ores:2>);
 
 // Increased Nickel chance in orechid
-mods.botania.Orechid.addOre(<ore:oreNickel>, 12000);
+mods.botania.Orechid.addOre(<ore:oreNickel>, 2970);
 
 // Makes the oredict entry "blockMossyCobblestone" which only contains mossy cobblestone
 val myEntry = <ore:blockMossyCobblestone>;


### PR DESCRIPTION
As it turns out, the nickel spawn rate was already increased significantly to 12000.  This is between copper (8000) and iron (20000).  I adjusted it downward to 3000 to match gold based on instructions in the discord server.  