### PR TITLE
Fix tin ingots crafting into osmium nuggets

### DIFF
--- a/scripts/mod-specific scripts/mekanism.zs
+++ b/scripts/mod-specific scripts/mekanism.zs
@@ -391,6 +391,9 @@ mods.refraction.AssemblyTable.addRecipe("Refined Glowstone Block", <mekanism:bas
     [<ore:ingotElectrum>, <minecraft:glowstone_dust> * 6],
     16, 64, 255, 255, 255, 255, 0, 0);
 
+// remove osmium ingot to nugget recipe so it isn't replaced with tin	
+recipes.removeShaped(<mekanism:nugget:1> * 9, [[<ore:ingotOsmium>]]);		
+	
 recipes.replaceAllOccurences(<ore:ingotOsmium>, <ore:ingotTin>);
 recipes.replaceAllOccurences(<mekanism:ingot:1>, <ore:ingotTin>);
 


### PR DESCRIPTION
The mekanism CT script replaces all instances of osmium ingots with tin ingots.  This PR removes the Osmium Ingot -> Osmium Nugget recipe before this process so you can't craft osmium nuggets from tin ingots.  