### PR TITLE
Added '192. Craft iron, gold, copper, tin, bronze and nickel gears in…

### DIFF
--- a/scripts/mod-specific scripts/forestry.zs
+++ b/scripts/mod-specific scripts/forestry.zs
@@ -1,4 +1,6 @@
 import crafttweaker.item.IItemStack;
+import crafttweaker.oredict.IOreDictEntry;
+
 // Disable forestry multifarms
 val itemsToDisable =[
   // Multifarm blocks
@@ -39,3 +41,41 @@ recipes.addShaped("menril_to_fertilizer", <forestry:fertilizer_compound> * 16,
 	[[<ore:dustAsh>, <ore:dustAsh>, <ore:dustAsh>], 
 	 [<ore:dustAsh>, <integrateddynamics:crystalized_menril_chunk>, <ore:dustAsh>], 
 	 [<ore:dustAsh>, <ore:dustAsh>, <ore:dustAsh>]]);
+
+// Craft iron, gold, copper, tin, bronze and nickel gears in the thermionic fabricator.
+val gearStone = <ore:gearStone>;
+var metalObjects as IOreDictEntry[string][string] = {
+    iron: {
+        gear: <ore:gearIron>,
+        ingot: <ore:ingotIron>
+    },
+    gold: {
+        gear: <ore:gearGold>,
+        ingot: <ore:ingotGold>
+    },
+    copper: {
+        gear: <ore:gearCopper>,
+        ingot: <ore:ingotCopper>
+    },
+    tin: {
+        gear: <ore:gearTin>,
+        ingot: <ore:ingotTin>
+    },
+    bronze: {
+        gear: <ore:gearBronze>,
+        ingot: <ore:ingotBronze>
+    },
+	nickel: {
+        gear: <ore:gearNickel>,
+        ingot: <ore:ingotNickel>
+    }
+};
+
+for key, value in metalObjects {
+    mods.forestry.ThermionicFabricator.addCast(value.gear.firstItem,
+        [[null, value.ingot, null],
+        [value.ingot, gearStone, value.ingot],
+        [null, value.ingot, null]],
+        <liquid: glass> * 200
+    ); 
+}


### PR DESCRIPTION
Like the title says, I added the recipe for 

> 192. Craft iron, gold, copper, tin, bronze and nickel gears in the thermionic fabricator.
These recipes will require 4 ingots and 1 stone gear.

However do note, currently the output will be the first item of the corresponding metal gear Ore Dict, which might have undesirable results. In my testing, without changing any Ore Dict, it will add the recipe to Railcraft's Iron Gear, Buildcraft's Gold Gear, and Thermal Foundation's for the other gears.